### PR TITLE
Add multi-threaded compilation support

### DIFF
--- a/jspc-compiler-api/src/main/java/org/codehaus/mojo/jspc/compiler/JspCompiler.java
+++ b/jspc-compiler-api/src/main/java/org/codehaus/mojo/jspc/compiler/JspCompiler.java
@@ -60,6 +60,10 @@ public interface JspCompiler {
     void setCompilerSourceVM(String source);
 
     void setCompilerTargetVM(String target);
-
+    
+    void setCompileThreads(int threads);
+    
+    void setCompileTimeout(long timeout);
+    
     void compile(Iterable<File> jspFiles) throws Exception;
 }

--- a/jspc-compilers/jspc-compiler-tomcat5/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat5/JspCompilerImpl.java
+++ b/jspc-compilers/jspc-compiler-tomcat5/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat5/JspCompilerImpl.java
@@ -28,7 +28,7 @@ import org.apache.jasper.JspC;
 import org.codehaus.mojo.jspc.compiler.JspCompiler;
 
 /**
- * JSP compiler for Tomcat 5.
+ * JSP compiler for Tomcat 5. Does NOT support multi-threaded compilation.
  *
  * @version $Id$
  */

--- a/jspc-compilers/jspc-compiler-tomcat6/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat6/JspCompilerImpl.java
+++ b/jspc-compilers/jspc-compiler-tomcat6/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat6/JspCompilerImpl.java
@@ -28,7 +28,7 @@ import org.apache.jasper.JspC;
 import org.codehaus.mojo.jspc.compiler.JspCompiler;
 
 /**
- * JSP compiler for Tomcat 6.
+ * JSP compiler for Tomcat 6. Supports multi-threaded compilation.
  *
  * @version $Id$
  */

--- a/jspc-compilers/jspc-compiler-tomcat6/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat6/JspCompilerImpl.java
+++ b/jspc-compilers/jspc-compiler-tomcat6/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat6/JspCompilerImpl.java
@@ -33,12 +33,12 @@ import org.codehaus.mojo.jspc.compiler.JspCompiler;
  * @version $Id$
  */
 public class JspCompilerImpl implements JspCompiler {
-    private final JspC jspc;
+    private final MultiThreadedJspC jspc;
     private boolean showSuccess = false;
     private boolean listErrors = false;
     
     public JspCompilerImpl() {
-        jspc = new JspC();
+        jspc = new MultiThreadedJspC();
         jspc.setFailOnError(true);
     }
 
@@ -129,5 +129,13 @@ public class JspCompilerImpl implements JspCompiler {
         jspc.setArgs(args.toArray(new String[args.size()]));
 
         jspc.execute();
+    }
+
+    public void setCompileThreads(int threads) {
+        jspc.setThreads(threads);
+    }
+
+    public void setCompileTimeout(long timeout) {
+        jspc.setCompilationTimeout(timeout);
     }
 }

--- a/jspc-compilers/jspc-compiler-tomcat6/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat6/MultiThreadedJspC.java
+++ b/jspc-compilers/jspc-compiler-tomcat6/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat6/MultiThreadedJspC.java
@@ -1,0 +1,244 @@
+package org.codehaus.mojo.jspc.compiler.tomcat6;
+
+import java.io.BufferedReader;
+import java.io.CharArrayWriter;
+import java.io.EOFException;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.Reader;
+import java.io.Writer;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Stack;
+import java.util.StringTokenizer;
+import java.util.Vector;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import javax.servlet.jsp.tagext.TagLibraryInfo;
+
+import org.apache.jasper.JasperException;
+import org.apache.jasper.JspC;
+import org.apache.jasper.JspCompilationContext;
+import org.apache.jasper.Options;
+import org.apache.jasper.compiler.Compiler;
+import org.apache.jasper.compiler.JspConfig;
+import org.apache.jasper.compiler.JspRuntimeContext;
+import org.apache.jasper.compiler.Localizer;
+import org.apache.jasper.compiler.TagPluginManager;
+import org.apache.jasper.compiler.TldLocationsCache;
+import org.apache.jasper.servlet.JspCServletContext;
+import org.apache.juli.logging.Log;
+import org.apache.juli.logging.LogFactory;
+import org.apache.tools.ant.AntClassLoader;
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.Task;
+import org.apache.tools.ant.util.FileUtils;
+
+/**
+* Shell for the jspc compiler.  Handles all options associated with the
+* command line and creates compilation contexts which it then compiles
+* according to the specified options.
+*
+* This version can process files from a _single_ webapp at once, i.e.
+* a single docbase can be specified.
+*
+* It can be used as an Ant task using:
+* <pre>
+*   &lt;taskdef classname="org.apache.jasper.JspC" name="jasper" &gt;
+*      &lt;classpath&gt;
+*          &lt;pathelement location="${java.home}/../lib/tools.jar"/&gt;
+*          &lt;fileset dir="${ENV.CATALINA_HOME}/lib"&gt;
+*              &lt;include name="*.jar"/&gt;
+*          &lt;/fileset&gt;
+*          &lt;path refid="myjars"/&gt;
+*       &lt;/classpath&gt;
+*  &lt;/taskdef&gt;
+*
+*  &lt;jasper verbose="0"
+*           package="my.package"
+*           uriroot="${webapps.dir}/${webapp.name}"
+*           webXmlFragment="${build.dir}/generated_web.xml"
+*           outputDir="${webapp.dir}/${webapp.name}/WEB-INF/src/my/package" /&gt;
+* </pre>
+*
+* @author Danno Ferrin
+* @author Pierre Delisle
+* @author Costin Manolache
+* @author Yoav Shapira
+*/
+public class MultiThreadedJspC extends JspC {
+    // Logger
+   private static final Log log = LogFactory.getLog(MultiThreadedJspC.class);
+    
+   private int threads = 1;
+   private long compilationTimeout = TimeUnit.MINUTES.toMinutes(30);
+   
+   
+   public int getThreads() {
+       return threads;
+   }
+
+   public void setThreads(int threads) {
+       this.threads = threads;
+   }
+   
+   public long getCompilationTimeout() {
+       return compilationTimeout;
+   }
+    
+   public void setCompilationTimeout(long compilationTimeoutMinutes) {
+       this.compilationTimeout = compilationTimeoutMinutes;
+   }
+   
+   /**
+    * Executes the compilation.
+    *
+    * @throws JasperException If an error occurs
+    */
+   @Override
+   public void execute() {
+       if(log.isDebugEnabled()) {
+           log.debug("execute() starting for " + pages.size() + " pages.");
+       }
+
+       try {
+           if (uriRoot == null) {
+               if( pages.size() == 0 ) {
+                   throw new JasperException(
+                       Localizer.getMessage("jsp.error.jspc.missingTarget"));
+               }
+               String firstJsp = pages.get( 0 ).toString();
+               File firstJspF = new File( firstJsp );
+               if (!firstJspF.exists()) {
+                   throw new JasperException(
+                       Localizer.getMessage("jspc.error.fileDoesNotExist",
+                                            firstJsp));
+               }
+               locateUriRoot( firstJspF );
+           }
+
+           if (uriRoot == null) {
+               throw new JasperException(
+                   Localizer.getMessage("jsp.error.jspc.no_uriroot"));
+           }
+
+           File uriRootF = new File(uriRoot);
+           if (!uriRootF.isDirectory()) {
+               throw new JasperException(
+                   Localizer.getMessage("jsp.error.jspc.uriroot_not_dir"));
+           }
+
+           if(context == null) {
+               initServletContext();
+           }
+
+           // No explicit pages, we'll process all .jsp in the webapp
+           if (pages.size() == 0) {
+               scanFiles(uriRootF);
+           }
+
+           initWebXml();
+           
+           log.info("compiling with " + getThreads() + " threads");
+           ExecutorService executor = Executors.newFixedThreadPool(getThreads());
+           final List<JasperException> errorCollector = Collections.synchronizedList(new ArrayList<JasperException>());
+           
+           for (Object p : pages) {
+               String nextjsp = p.toString();
+               File fjsp = new File(nextjsp);
+               if (!fjsp.isAbsolute()) {
+                   fjsp = new File(uriRootF, nextjsp);
+               }
+               if (!fjsp.exists()) {
+                   if (log.isWarnEnabled()) {
+                       log.warn
+                           (Localizer.getMessage
+                            ("jspc.error.fileDoesNotExist", fjsp.toString()));
+                   }
+                   continue;
+               }
+               String s = fjsp.getAbsolutePath();
+               if (s.startsWith(uriRoot)) {
+                   nextjsp = s.substring(uriRoot.length());
+               }
+               if (nextjsp.startsWith("." + File.separatorChar)) {
+                   nextjsp = nextjsp.substring(2);
+               }
+               
+               final String jspToCompile = nextjsp;
+               executor.execute(new Runnable() {
+                public void run() {
+                    try {
+                        processFile(jspToCompile);
+                    } catch (JasperException je) {
+                        errorCollector.add(je);
+                    }
+                }
+            });
+           }
+           
+           executor.shutdown();
+           executor.awaitTermination(compilationTimeout, TimeUnit.MILLISECONDS);
+           
+           if (errorCollector.size() > 0) {
+               throwBuildException(errorCollector);
+           }
+
+           completeWebXml();
+
+           if (addWebXmlMappings) {
+               mergeIntoWebXml();
+           }
+
+       } catch (IOException ioe) {
+           throw new BuildException(ioe);
+
+       } catch (JasperException je) {
+           throwBuildException(Arrays.asList(je));
+       } catch (InterruptedException e) {
+        throw new BuildException(e);
+       } finally {
+           if (loader != null) {
+               LogFactory.release(loader);
+           }
+       }
+   }
+   
+   private void throwBuildException(List<JasperException> errorCollector) {
+       StringBuilder errOut = new StringBuilder();
+       
+       for (JasperException je : errorCollector) {
+           Throwable rootCause = je;
+           while (rootCause instanceof JasperException
+                   && ((JasperException) rootCause).getRootCause() != null) {
+               rootCause = ((JasperException) rootCause).getRootCause();
+           }
+           if (rootCause != errorCollector) {
+               rootCause.printStackTrace();
+           }
+           errOut.append(rootCause.getMessage()).append('\n');
+       }
+       
+    // throw exception with first error encountered as cause, but all messages
+       throw new BuildException(errOut.toString(), errorCollector.get(0)); 
+   }   
+}

--- a/jspc-compilers/jspc-compiler-tomcat7-multithreaded/.gitignore
+++ b/jspc-compilers/jspc-compiler-tomcat7-multithreaded/.gitignore
@@ -1,0 +1,4 @@
+/target
+/.project
+/.classpath
+/.settings

--- a/jspc-compilers/jspc-compiler-tomcat7-multithreaded/NOTICE
+++ b/jspc-compilers/jspc-compiler-tomcat7-multithreaded/NOTICE
@@ -1,0 +1,40 @@
+Copyright 2010, JA-SIG, Inc.
+This project includes software developed by Jasig.
+http://www.jasig.org/
+
+Licensed under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at:
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+
+
+  Apache Ant Core under The Apache Software License, Version 2.0
+  Apache Ant Launcher under The Apache Software License, Version 2.0
+  Commons Lang under The Apache Software License, Version 2.0
+  Eclipse ECJ under Eclipse Public License v1.0
+  JSPC Compiler API under Apache License Version 2.0
+  JSPC Compiler for Tomcat 7 under Apache License Version 2.0
+  Plexus :: Component Annotations under The Apache Software License, Version 2.0
+  tomcat-annotations-api under Apache License, Version 2.0
+  tomcat-api under Apache License, Version 2.0
+  tomcat-el-api under Apache License, Version 2.0
+  tomcat-jasper under Apache License, Version 2.0
+  tomcat-jasper-el under Apache License, Version 2.0
+  tomcat-jsp-api under Apache License, Version 2.0 and
+        Common Development And Distribution License (CDDL) Version 1.0
+  tomcat-juli under Apache License, Version 2.0
+  tomcat-servlet-api under Apache License, Version 2.0 and
+        Common Development And Distribution License (CDDL) Version 1.0
+  tomcat-util under Apache License, Version 2.0
+
+ 
+This project also includes code under copywrite of the following:
+ Jeff Genender - Copyright 2005 

--- a/jspc-compilers/jspc-compiler-tomcat7-multithreaded/pom.xml
+++ b/jspc-compilers/jspc-compiler-tomcat7-multithreaded/pom.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<!-- $Id$ -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    
+    <parent>
+        <groupId>org.jasig.mojo.jspc</groupId>
+        <artifactId>jspc-compilers</artifactId>
+        <version>2.0.1-SNAPSHOT</version>
+    </parent>
+    
+    <artifactId>jspc-compiler-tomcat7-multithreaded</artifactId>
+    <name>JSPC Compiler for Tomcat 7</name>
+
+    <properties>
+        <tomcatVersion>7.0.39</tomcatVersion>
+    </properties>
+    
+    <dependencies>
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>jspc-compiler-api</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-component-annotations</artifactId>
+        </dependency>
+            
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.apache.ant</groupId>
+            <artifactId>ant</artifactId>
+            <version>1.9.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-jasper</artifactId>
+            <version>${tomcatVersion}</version>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-annotations-api</artifactId>
+            <version>${tomcatVersion}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.mycila.maven-license-plugin</groupId>
+                <artifactId>maven-license-plugin</artifactId>
+                <configuration>
+                   <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-component-metadata</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/jspc-compilers/jspc-compiler-tomcat7-multithreaded/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat7/JspCompilerFactoryImpl.java
+++ b/jspc-compilers/jspc-compiler-tomcat7-multithreaded/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat7/JspCompilerFactoryImpl.java
@@ -1,0 +1,31 @@
+/**
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.codehaus.mojo.jspc.compiler.tomcat7;
+
+import org.codehaus.mojo.jspc.compiler.JspCompiler;
+import org.codehaus.mojo.jspc.compiler.JspCompilerFactory;
+import org.codehaus.plexus.component.annotations.Component;
+
+@Component(role=JspCompilerFactory.class, hint="tomcat7")
+public class JspCompilerFactoryImpl implements JspCompilerFactory {
+
+    public JspCompiler createJspCompiler() {
+        return new JspCompilerImpl();
+    }
+}

--- a/jspc-compilers/jspc-compiler-tomcat7-multithreaded/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat7/JspCompilerImpl.java
+++ b/jspc-compilers/jspc-compiler-tomcat7-multithreaded/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat7/JspCompilerImpl.java
@@ -17,28 +17,27 @@
  * under the License.
  */
 
-package org.codehaus.mojo.jspc.compiler.tomcat5;
+package org.codehaus.mojo.jspc.compiler.tomcat7;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.jasper.JspC;
 import org.codehaus.mojo.jspc.compiler.JspCompiler;
 
 /**
- * JSP compiler for Tomcat 5.
+ * JSP compiler for Tomcat 6.
  *
  * @version $Id$
  */
 public class JspCompilerImpl implements JspCompiler {
-    private final JspC jspc;
+    private final MultiThreadedJspC jspc;
     private boolean showSuccess = false;
     private boolean listErrors = false;
     
     public JspCompilerImpl() {
-        jspc = new JspC();
+        jspc = new MultiThreadedJspC();
         jspc.setFailOnError(true);
     }
 
@@ -126,21 +125,9 @@ public class JspCompilerImpl implements JspCompiler {
             args.add(jspFile.getAbsolutePath());
         }
         
+        jspc.setThreads(Integer.getInteger("jspc.threads", 1));
         jspc.setArgs(args.toArray(new String[args.size()]));
 
         jspc.execute();
-    }
-
-    // ignored, multithreading not supported on tomcat5
-    public void setCompileThreads(int threads) {
-        if (threads > 1) {
-            for (int i = 0; i < 3; i++) {
-                System.out.println("WARN: Multi-threaded compilation not supported with tomcat5 compiler");
-            }
-        }
-    }
-
-    // ignored, multithreading not supported on tomcat5
-    public void setCompileTimeout(long timeout) {
     }
 }

--- a/jspc-compilers/jspc-compiler-tomcat7-multithreaded/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat7/MultiThreadedJspC.java
+++ b/jspc-compilers/jspc-compiler-tomcat7-multithreaded/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat7/MultiThreadedJspC.java
@@ -1,0 +1,245 @@
+package org.codehaus.mojo.jspc.compiler.tomcat7;
+
+import java.io.BufferedReader;
+import java.io.CharArrayWriter;
+import java.io.EOFException;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.Reader;
+import java.io.Writer;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Stack;
+import java.util.StringTokenizer;
+import java.util.Vector;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import javax.servlet.jsp.tagext.TagLibraryInfo;
+
+import org.apache.jasper.JasperException;
+import org.apache.jasper.JspC;
+import org.apache.jasper.JspCompilationContext;
+import org.apache.jasper.Options;
+import org.apache.jasper.compiler.Compiler;
+import org.apache.jasper.compiler.JspConfig;
+import org.apache.jasper.compiler.JspRuntimeContext;
+import org.apache.jasper.compiler.Localizer;
+import org.apache.jasper.compiler.TagPluginManager;
+import org.apache.jasper.compiler.TldLocationsCache;
+import org.apache.jasper.servlet.JspCServletContext;
+import org.apache.juli.logging.Log;
+import org.apache.juli.logging.LogFactory;
+import org.apache.tools.ant.AntClassLoader;
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.Task;
+import org.apache.tools.ant.util.FileUtils;
+
+/**
+* Shell for the jspc compiler.  Handles all options associated with the
+* command line and creates compilation contexts which it then compiles
+* according to the specified options.
+*
+* This version can process files from a _single_ webapp at once, i.e.
+* a single docbase can be specified.
+*
+* It can be used as an Ant task using:
+* <pre>
+*   &lt;taskdef classname="org.apache.jasper.JspC" name="jasper" &gt;
+*      &lt;classpath&gt;
+*          &lt;pathelement location="${java.home}/../lib/tools.jar"/&gt;
+*          &lt;fileset dir="${ENV.CATALINA_HOME}/lib"&gt;
+*              &lt;include name="*.jar"/&gt;
+*          &lt;/fileset&gt;
+*          &lt;path refid="myjars"/&gt;
+*       &lt;/classpath&gt;
+*  &lt;/taskdef&gt;
+*
+*  &lt;jasper verbose="0"
+*           package="my.package"
+*           uriroot="${webapps.dir}/${webapp.name}"
+*           webXmlFragment="${build.dir}/generated_web.xml"
+*           outputDir="${webapp.dir}/${webapp.name}/WEB-INF/src/my/package" /&gt;
+* </pre>
+*
+* @author Danno Ferrin
+* @author Pierre Delisle
+* @author Costin Manolache
+* @author Yoav Shapira
+*/
+public class MultiThreadedJspC extends JspC {
+    // Logger
+   private static final Log log = LogFactory.getLog(MultiThreadedJspC.class);
+    
+   private int threads = 1;
+   private long compilationTimeoutMinutes = 30;
+   
+   
+   public int getThreads() {
+       return threads;
+   }
+
+   public void setThreads(int threads) {
+       this.threads = threads;
+   }
+   
+   public long getCompilationTimeoutMinutes() {
+       return compilationTimeoutMinutes;
+   }
+    
+   public void setCompilationTimeoutMinutes(long compilationTimeoutMinutes) {
+       this.compilationTimeoutMinutes = compilationTimeoutMinutes;
+   }
+   
+   /**
+    * Executes the compilation.
+    *
+    * @throws JasperException If an error occurs
+    */
+   @Override
+   public void execute() {
+       if(log.isDebugEnabled()) {
+           log.debug("execute() starting for " + pages.size() + " pages.");
+       }
+
+       try {
+           if (uriRoot == null) {
+               if( pages.size() == 0 ) {
+                   throw new JasperException(
+                       Localizer.getMessage("jsp.error.jspc.missingTarget"));
+               }
+               String firstJsp = pages.get( 0 );
+               File firstJspF = new File( firstJsp );
+               if (!firstJspF.exists()) {
+                   throw new JasperException(
+                       Localizer.getMessage("jspc.error.fileDoesNotExist",
+                                            firstJsp));
+               }
+               locateUriRoot( firstJspF );
+           }
+
+           if (uriRoot == null) {
+               throw new JasperException(
+                   Localizer.getMessage("jsp.error.jspc.no_uriroot"));
+           }
+
+           File uriRootF = new File(uriRoot);
+           if (!uriRootF.isDirectory()) {
+               throw new JasperException(
+                   Localizer.getMessage("jsp.error.jspc.uriroot_not_dir"));
+           }
+
+           if(context == null) {
+               initServletContext();
+           }
+
+           // No explicit pages, we'll process all .jsp in the webapp
+           if (pages.size() == 0) {
+               scanFiles(uriRootF);
+           }
+
+           initWebXml();
+           
+           log.info("compiling with " + getThreads() + " threads");
+           ExecutorService executor = Executors.newFixedThreadPool(getThreads());
+           final List<JasperException> errorCollector = Collections.synchronizedList(new ArrayList<JasperException>());
+           
+           for (String nextjsp : pages) {            
+               File fjsp = new File(nextjsp);
+               if (!fjsp.isAbsolute()) {
+                   fjsp = new File(uriRootF, nextjsp);
+               }
+               if (!fjsp.exists()) {
+                   if (log.isWarnEnabled()) {
+                       log.warn
+                           (Localizer.getMessage
+                            ("jspc.error.fileDoesNotExist", fjsp.toString()));
+                   }
+                   continue;
+               }
+               String s = fjsp.getAbsolutePath();
+               if (s.startsWith(uriRoot)) {
+                   nextjsp = s.substring(uriRoot.length());
+               }
+               if (nextjsp.startsWith("." + File.separatorChar)) {
+                   nextjsp = nextjsp.substring(2);
+               }
+               
+               final String jspToCompile = nextjsp;
+               executor.execute(new Runnable() {
+                public void run() {
+                    try {
+                        processFile(jspToCompile);
+                    } catch (JasperException je) {
+                        errorCollector.add(je);
+                    }
+                }
+            });
+           }
+           
+           executor.shutdown();
+           executor.awaitTermination(compilationTimeoutMinutes, TimeUnit.MINUTES);
+           
+           if (errorCollector.size() > 0) {
+               throwBuildException(errorCollector);
+           }
+
+           completeWebXml();
+
+           if (addWebXmlMappings) {
+               mergeIntoWebXml();
+           }
+
+       } catch (IOException ioe) {
+           throw new BuildException(ioe);
+
+       } catch (JasperException je) {
+           throwBuildException(Arrays.asList(je));
+       } catch (InterruptedException e) {
+        throw new BuildException(e);
+       } finally {
+           if (loader != null) {
+               LogFactory.release(loader);
+           }
+       }
+   }
+   
+   private void throwBuildException(List<JasperException> errorCollector) {
+       StringBuilder errOut = new StringBuilder();
+       
+       for (JasperException je : errorCollector) {
+           Throwable rootCause = je;
+           while (rootCause instanceof JasperException
+                   && ((JasperException) rootCause).getRootCause() != null) {
+               rootCause = ((JasperException) rootCause).getRootCause();
+           }
+           if (rootCause != errorCollector) {
+               rootCause.printStackTrace();
+           }
+           errOut.append(rootCause.getMessage()).append('\n');
+       }
+       
+    // throw exception with first error encountered as cause, but all messages
+       throw new BuildException(errOut.toString(), errorCollector.get(0)); 
+   }
+
+   
+}

--- a/jspc-compilers/jspc-compiler-tomcat7-multithreaded/src/site/apt/index.apt
+++ b/jspc-compilers/jspc-compiler-tomcat7-multithreaded/src/site/apt/index.apt
@@ -1,0 +1,29 @@
+ ------
+ Introduction
+ ------
+ ------
+ $Id: index.apt 6588 2008-03-28 12:22:57Z bentmann $
+
+~~ 
+~~ Licensed to the Apache Software Foundation (ASF) under one
+~~ or more contributor license agreements.  See the NOTICE file
+~~ distributed with this work for additional information
+~~ regarding copyright ownership.  The ASF licenses this file
+~~ to you under the Apache License, Version 2.0 (the
+~~ "License"); you may not use this file except in compliance
+~~ with the License.  You may obtain a copy of the License at
+~~
+~~  http://www.apache.org/licenses/LICENSE-2.0
+~~
+~~ Unless required by applicable law or agreed to in writing,
+~~ software distributed under the License is distributed on an
+~~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+~~ KIND, either express or implied.  See the License for the
+~~ specific language governing permissions and limitations
+~~ under the License.
+~~
+
+Introduction
+
+ Provides JSP compilation support for {{{http://tomcat.apache.org/tomcat-7.0-doc}Tomcat 7}}.
+

--- a/jspc-compilers/jspc-compiler-tomcat7-multithreaded/src/site/site.xml
+++ b/jspc-compilers/jspc-compiler-tomcat7-multithreaded/src/site/site.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<!-- $Id: site.xml 17321 2012-08-16 03:46:27Z shinsuke $ -->
+
+<project xmlns="http://maven.apache.org/DECORATION/1.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/DECORATION/1.0.0 http://maven.apache.org/xsd/decoration-1.0.0.xsd"
+    name="${project.name} ${project.version}">
+    
+    <bannerLeft>
+        <name>${project.name}</name>
+    </bannerLeft>
+    <bannerRight>
+        <name>Jasig</name>
+        <src>http://www.jasig.org/sites/all/themes/jasig2/logo.png</src>
+        <href>http://www.jasig.org</href>
+    </bannerRight>
+    <publishDate format="MM-dd-yy hh:mm zz" position="right" />
+    <version position="right" />
+    
+
+    <body>
+        <menu ref="parent" />
+        <menu name="Overview">
+            <item name="Introduction" href="index.html"/>
+        </menu>
+        <menu ref="modules" />
+        <menu ref="reports" />
+    </body>
+</project>

--- a/jspc-compilers/jspc-compiler-tomcat7/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat7/JspCompilerImpl.java
+++ b/jspc-compilers/jspc-compiler-tomcat7/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat7/JspCompilerImpl.java
@@ -27,7 +27,7 @@ import org.apache.commons.lang.StringUtils;
 import org.codehaus.mojo.jspc.compiler.JspCompiler;
 
 /**
- * JSP compiler for Tomcat 6.
+ * JSP compiler for Tomcat 7. Supports multi-threaded compilation.
  *
  * @version $Id$
  */

--- a/jspc-compilers/jspc-compiler-tomcat7/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat7/JspCompilerImpl.java
+++ b/jspc-compilers/jspc-compiler-tomcat7/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat7/JspCompilerImpl.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.jasper.JspC;
 import org.codehaus.mojo.jspc.compiler.JspCompiler;
 
 /**
@@ -33,12 +32,12 @@ import org.codehaus.mojo.jspc.compiler.JspCompiler;
  * @version $Id$
  */
 public class JspCompilerImpl implements JspCompiler {
-    private final JspC jspc;
+    private final MultiThreadedJspC jspc;
     private boolean showSuccess = false;
     private boolean listErrors = false;
     
     public JspCompilerImpl() {
-        jspc = new JspC();
+        jspc = new MultiThreadedJspC();
         jspc.setFailOnError(true);
     }
 
@@ -129,5 +128,13 @@ public class JspCompilerImpl implements JspCompiler {
         jspc.setArgs(args.toArray(new String[args.size()]));
 
         jspc.execute();
+    }
+
+    public void setCompileThreads(int threads) {
+        jspc.setThreads(threads);
+    }
+
+    public void setCompileTimeout(long timeout) {
+        jspc.setCompilationTimeout(timeout);
     }
 }

--- a/jspc-compilers/jspc-compiler-tomcat7/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat7/MultiThreadedJspC.java
+++ b/jspc-compilers/jspc-compiler-tomcat7/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat7/MultiThreadedJspC.java
@@ -153,7 +153,9 @@ public class MultiThreadedJspC extends JspC {
 
            // No explicit pages, we'll process all .jsp in the webapp
            if (pages.size() == 0) {
+               long start = System.currentTimeMillis();
                scanFiles(uriRootF);
+               log.info("scanned for jsp files in " + (System.currentTimeMillis() - start) + "ms"); 
            }
 
            initWebXml();
@@ -187,7 +189,9 @@ public class MultiThreadedJspC extends JspC {
                executor.execute(new Runnable() {
                 public void run() {
                     try {
+                        long start = System.currentTimeMillis();
                         processFile(jspToCompile);
+                        log.info("compiled file " + jspToCompile + " in " + (System.currentTimeMillis() - start) + "ms");
                     } catch (JasperException je) {
                         errorCollector.add(je);
                     }

--- a/jspc-compilers/jspc-compiler-tomcat7/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat7/MultiThreadedJspC.java
+++ b/jspc-compilers/jspc-compiler-tomcat7/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat7/MultiThreadedJspC.java
@@ -1,0 +1,245 @@
+package org.codehaus.mojo.jspc.compiler.tomcat7;
+
+import java.io.BufferedReader;
+import java.io.CharArrayWriter;
+import java.io.EOFException;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.Reader;
+import java.io.Writer;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Stack;
+import java.util.StringTokenizer;
+import java.util.Vector;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import javax.servlet.jsp.tagext.TagLibraryInfo;
+
+import org.apache.jasper.JasperException;
+import org.apache.jasper.JspC;
+import org.apache.jasper.JspCompilationContext;
+import org.apache.jasper.Options;
+import org.apache.jasper.compiler.Compiler;
+import org.apache.jasper.compiler.JspConfig;
+import org.apache.jasper.compiler.JspRuntimeContext;
+import org.apache.jasper.compiler.Localizer;
+import org.apache.jasper.compiler.TagPluginManager;
+import org.apache.jasper.compiler.TldLocationsCache;
+import org.apache.jasper.servlet.JspCServletContext;
+import org.apache.juli.logging.Log;
+import org.apache.juli.logging.LogFactory;
+import org.apache.tools.ant.AntClassLoader;
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.Task;
+import org.apache.tools.ant.util.FileUtils;
+
+/**
+* Shell for the jspc compiler.  Handles all options associated with the
+* command line and creates compilation contexts which it then compiles
+* according to the specified options.
+*
+* This version can process files from a _single_ webapp at once, i.e.
+* a single docbase can be specified.
+*
+* It can be used as an Ant task using:
+* <pre>
+*   &lt;taskdef classname="org.apache.jasper.JspC" name="jasper" &gt;
+*      &lt;classpath&gt;
+*          &lt;pathelement location="${java.home}/../lib/tools.jar"/&gt;
+*          &lt;fileset dir="${ENV.CATALINA_HOME}/lib"&gt;
+*              &lt;include name="*.jar"/&gt;
+*          &lt;/fileset&gt;
+*          &lt;path refid="myjars"/&gt;
+*       &lt;/classpath&gt;
+*  &lt;/taskdef&gt;
+*
+*  &lt;jasper verbose="0"
+*           package="my.package"
+*           uriroot="${webapps.dir}/${webapp.name}"
+*           webXmlFragment="${build.dir}/generated_web.xml"
+*           outputDir="${webapp.dir}/${webapp.name}/WEB-INF/src/my/package" /&gt;
+* </pre>
+*
+* @author Danno Ferrin
+* @author Pierre Delisle
+* @author Costin Manolache
+* @author Yoav Shapira
+*/
+public class MultiThreadedJspC extends JspC {
+    // Logger
+   private static final Log log = LogFactory.getLog(MultiThreadedJspC.class);
+    
+   private int threads = 1;
+   private long compilationTimeout = TimeUnit.MINUTES.toMinutes(30);
+   
+   
+   public int getThreads() {
+       return threads;
+   }
+
+   public void setThreads(int threads) {
+       this.threads = threads;
+   }
+   
+   public long getCompilationTimeout() {
+       return compilationTimeout;
+   }
+    
+   public void setCompilationTimeout(long compilationTimeout) {
+       this.compilationTimeout = compilationTimeout;
+   }
+   
+   /**
+    * Executes the compilation.
+    *
+    * @throws JasperException If an error occurs
+    */
+   @Override
+   public void execute() {
+       if(log.isDebugEnabled()) {
+           log.debug("execute() starting for " + pages.size() + " pages.");
+       }
+
+       try {
+           if (uriRoot == null) {
+               if( pages.size() == 0 ) {
+                   throw new JasperException(
+                       Localizer.getMessage("jsp.error.jspc.missingTarget"));
+               }
+               String firstJsp = pages.get( 0 );
+               File firstJspF = new File( firstJsp );
+               if (!firstJspF.exists()) {
+                   throw new JasperException(
+                       Localizer.getMessage("jspc.error.fileDoesNotExist",
+                                            firstJsp));
+               }
+               locateUriRoot( firstJspF );
+           }
+
+           if (uriRoot == null) {
+               throw new JasperException(
+                   Localizer.getMessage("jsp.error.jspc.no_uriroot"));
+           }
+
+           File uriRootF = new File(uriRoot);
+           if (!uriRootF.isDirectory()) {
+               throw new JasperException(
+                   Localizer.getMessage("jsp.error.jspc.uriroot_not_dir"));
+           }
+
+           if(context == null) {
+               initServletContext();
+           }
+
+           // No explicit pages, we'll process all .jsp in the webapp
+           if (pages.size() == 0) {
+               scanFiles(uriRootF);
+           }
+
+           initWebXml();
+           
+           log.info("compiling with " + getThreads() + " threads");
+           ExecutorService executor = Executors.newFixedThreadPool(getThreads());
+           final List<JasperException> errorCollector = Collections.synchronizedList(new ArrayList<JasperException>());
+           
+           for (String nextjsp : pages) {            
+               File fjsp = new File(nextjsp);
+               if (!fjsp.isAbsolute()) {
+                   fjsp = new File(uriRootF, nextjsp);
+               }
+               if (!fjsp.exists()) {
+                   if (log.isWarnEnabled()) {
+                       log.warn
+                           (Localizer.getMessage
+                            ("jspc.error.fileDoesNotExist", fjsp.toString()));
+                   }
+                   continue;
+               }
+               String s = fjsp.getAbsolutePath();
+               if (s.startsWith(uriRoot)) {
+                   nextjsp = s.substring(uriRoot.length());
+               }
+               if (nextjsp.startsWith("." + File.separatorChar)) {
+                   nextjsp = nextjsp.substring(2);
+               }
+               
+               final String jspToCompile = nextjsp;
+               executor.execute(new Runnable() {
+                public void run() {
+                    try {
+                        processFile(jspToCompile);
+                    } catch (JasperException je) {
+                        errorCollector.add(je);
+                    }
+                }
+            });
+           }
+           
+           executor.shutdown();
+           executor.awaitTermination(compilationTimeout, TimeUnit.MILLISECONDS);
+           
+           if (errorCollector.size() > 0) {
+               throwBuildException(errorCollector);
+           }
+
+           completeWebXml();
+
+           if (addWebXmlMappings) {
+               mergeIntoWebXml();
+           }
+
+       } catch (IOException ioe) {
+           throw new BuildException(ioe);
+
+       } catch (JasperException je) {
+           throwBuildException(Arrays.asList(je));
+       } catch (InterruptedException e) {
+        throw new BuildException(e);
+       } finally {
+           if (loader != null) {
+               LogFactory.release(loader);
+           }
+       }
+   }
+   
+   private void throwBuildException(List<JasperException> errorCollector) {
+       StringBuilder errOut = new StringBuilder();
+       
+       for (JasperException je : errorCollector) {
+           Throwable rootCause = je;
+           while (rootCause instanceof JasperException
+                   && ((JasperException) rootCause).getRootCause() != null) {
+               rootCause = ((JasperException) rootCause).getRootCause();
+           }
+           if (rootCause != errorCollector) {
+               rootCause.printStackTrace();
+           }
+           errOut.append(rootCause.getMessage()).append('\n');
+       }
+       
+    // throw exception with first error encountered as cause, but all messages
+       throw new BuildException(errOut.toString(), errorCollector.get(0)); 
+   }
+
+   
+}

--- a/jspc-maven-plugin/src/main/java/org/codehaus/mojo/jspc/CompilationMojoSupport.java
+++ b/jspc-maven-plugin/src/main/java/org/codehaus/mojo/jspc/CompilationMojoSupport.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.XmlStreamReader;
@@ -208,6 +209,17 @@ abstract class CompilationMojoSupport extends AbstractMojo {
     @Parameter(defaultValue="true")
     boolean errorOnUseBeanInvalidClassAttribute;
 
+    /**
+     * Number of threads to compile with
+     */
+    @Parameter(defaultValue="1")
+    int compileThreads;
+    
+    /**
+     * maximum amount of time compilation can take or be killed in minutes 
+     */
+    @Parameter(defaultValue="5")
+    int compilationTimeout;
     //
     // Components
     //
@@ -314,6 +326,8 @@ abstract class CompilationMojoSupport extends AbstractMojo {
         jspCompiler.setErrorOnUseBeanInvalidClassAttribute(errorOnUseBeanInvalidClassAttribute);
         jspCompiler.setCompilerSourceVM(source);
         jspCompiler.setCompilerTargetVM(target);
+        jspCompiler.setCompileThreads(compileThreads);
+        jspCompiler.setCompileTimeout(TimeUnit.MINUTES.toMillis(compilationTimeout));
         
         // Make directories if needed
         workingDirectory.mkdirs();

--- a/src/site/apt/index.apt
+++ b/src/site/apt/index.apt
@@ -41,11 +41,18 @@ JSP Compilation Support for Maven
  In version 2 of the JSP plugin for Maven 2, the JSP compiler implementation is pluggable.
  Currently the following compilers are supported:
 
- * {{{./jspc-compilers/jspc-compiler-tomcat5/index.html}Tomcat 5 Compiler}}: Uses Tomcat 5.5.23 Jasper compiler.
+ * {{{./jspc-compilers/jspc-compiler-tomcat5/index.html}Tomcat 5 Compiler}}: Uses Tomcat 5.5.23 Jasper compiler. (Does NOT support multi-threaded compilation)
  
- * {{{./jspc-compilers/jspc-compiler-tomcat6/index.html}Tomcat 6 Compiler}}: Uses Tomcat 6.0.37 Jasper compiler.
+ * {{{./jspc-compilers/jspc-compiler-tomcat6/index.html}Tomcat 6 Compiler}}: Uses Tomcat 6.0.37 Jasper compiler. (Supports multi-threaded compilation)
 
- * {{{./jspc-compilers/jspc-compiler-tomcat7/index.html}Tomcat 7 Compiler}}: Uses Tomcat 6.0.39 Jasper compiler.
+ * {{{./jspc-compilers/jspc-compiler-tomcat7/index.html}Tomcat 7 Compiler}}: Uses Tomcat 7.0.39 Jasper compiler. (Supports multi-threaded compilation)
  
  []
 
+* Multi-threaded compilation
+
+Some compilers (Tomcat6/7) support compiling the jsps with multiple threads. 
+
+The number of threads is controlled by the 'compileThreads' parameter 
+
+The maximum time allowed for compilation to finish is controlled by the 'compilationTimeout' parameter, specified in minutes.


### PR DESCRIPTION
We have a project with a large number of JSPs and JspC take forever to compile them. I basically just created a subclass of JspC that submits the processFile method call to a thread pool executor. This significantly improved our compilation time. I couldn't subclass the tomcat5 version of JspC and have access to all of the necessary variables so rather than duplicate the entire JspC class I just didn't update the compiler to support multi-threading. 