### PR TITLE
Upgrade to tomcat 7.0.50 and to support ELInterpreter in JSPC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 /.classpath
 /.settings
 /target
+/.idea/
+*.iml
+/**/*.iml

--- a/jspc-compiler-api/pom.xml
+++ b/jspc-compiler-api/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.jasig.mojo.jspc</groupId>
         <artifactId>jspc</artifactId>
-        <version>2.0.0.1-EBAY</version>
+        <version>2.0.0.2-EBAY</version>
     </parent>
     
     <artifactId>jspc-compiler-api</artifactId>

--- a/jspc-compiler-api/pom.xml
+++ b/jspc-compiler-api/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.jasig.mojo.jspc</groupId>
         <artifactId>jspc</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.0.0.1-EBAY</version>
     </parent>
     
     <artifactId>jspc-compiler-api</artifactId>

--- a/jspc-compiler-api/pom.xml
+++ b/jspc-compiler-api/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.jasig.mojo.jspc</groupId>
         <artifactId>jspc</artifactId>
-        <version>2.0.0.2-EBAY</version>
+        <version>2.0.0.3-EBAY</version>
     </parent>
     
     <artifactId>jspc-compiler-api</artifactId>

--- a/jspc-compiler-api/pom.xml
+++ b/jspc-compiler-api/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.jasig.mojo.jspc</groupId>
         <artifactId>jspc</artifactId>
-        <version>2.0.0.3-EBAY</version>
+        <version>2.0.0.4-EBAY</version>
     </parent>
     
     <artifactId>jspc-compiler-api</artifactId>

--- a/jspc-compiler-api/src/main/java/org/codehaus/mojo/jspc/compiler/JspCompiler.java
+++ b/jspc-compiler-api/src/main/java/org/codehaus/mojo/jspc/compiler/JspCompiler.java
@@ -63,5 +63,7 @@ public interface JspCompiler {
 
     void setELInterpreterClass(String elInterpreterClass);
 
+    void setGenStringAsCharArray(boolean genStringAsCharArray);
+
     void compile(Iterable<File> jspFiles) throws Exception;
 }

--- a/jspc-compiler-api/src/main/java/org/codehaus/mojo/jspc/compiler/JspCompiler.java
+++ b/jspc-compiler-api/src/main/java/org/codehaus/mojo/jspc/compiler/JspCompiler.java
@@ -61,5 +61,7 @@ public interface JspCompiler {
 
     void setCompilerTargetVM(String target);
 
+    void setELInterpreterClass(String elInterpreterClass);
+
     void compile(Iterable<File> jspFiles) throws Exception;
 }

--- a/jspc-compiler-api/src/main/java/org/codehaus/mojo/jspc/compiler/JspCompiler.java
+++ b/jspc-compiler-api/src/main/java/org/codehaus/mojo/jspc/compiler/JspCompiler.java
@@ -65,5 +65,7 @@ public interface JspCompiler {
 
     void setGenStringAsCharArray(boolean genStringAsCharArray);
 
+    void setEnablePooling(boolean enablePooling);
+
     void compile(Iterable<File> jspFiles) throws Exception;
 }

--- a/jspc-compilers/jspc-compiler-tomcat5/pom.xml
+++ b/jspc-compilers/jspc-compiler-tomcat5/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.jasig.mojo.jspc</groupId>
         <artifactId>jspc-compilers</artifactId>
-        <version>2.0.0.3-EBAY</version>
+        <version>2.0.0.4-EBAY</version>
     </parent>
     
     <artifactId>jspc-compiler-tomcat5</artifactId>

--- a/jspc-compilers/jspc-compiler-tomcat5/pom.xml
+++ b/jspc-compilers/jspc-compiler-tomcat5/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.jasig.mojo.jspc</groupId>
         <artifactId>jspc-compilers</artifactId>
-        <version>2.0.0.2-EBAY</version>
+        <version>2.0.0.3-EBAY</version>
     </parent>
     
     <artifactId>jspc-compiler-tomcat5</artifactId>

--- a/jspc-compilers/jspc-compiler-tomcat5/pom.xml
+++ b/jspc-compilers/jspc-compiler-tomcat5/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.jasig.mojo.jspc</groupId>
         <artifactId>jspc-compilers</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.0.0.1-EBAY</version>
     </parent>
     
     <artifactId>jspc-compiler-tomcat5</artifactId>

--- a/jspc-compilers/jspc-compiler-tomcat5/pom.xml
+++ b/jspc-compilers/jspc-compiler-tomcat5/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.jasig.mojo.jspc</groupId>
         <artifactId>jspc-compilers</artifactId>
-        <version>2.0.0.1-EBAY</version>
+        <version>2.0.0.2-EBAY</version>
     </parent>
     
     <artifactId>jspc-compiler-tomcat5</artifactId>

--- a/jspc-compilers/jspc-compiler-tomcat5/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat5/JspCompilerImpl.java
+++ b/jspc-compilers/jspc-compiler-tomcat5/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat5/JspCompilerImpl.java
@@ -111,6 +111,10 @@ public class JspCompilerImpl implements JspCompiler {
         jspc.setCompilerTargetVM(target);
     }
 
+    public void setELInterpreterClass(String elInterpreterClass) {
+        //Unsupported in Tomcat 5
+    }
+
     public void compile(Iterable<File> jspFiles) throws Exception {
         final List<String> args = new ArrayList<String>();
         

--- a/jspc-compilers/jspc-compiler-tomcat5/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat5/JspCompilerImpl.java
+++ b/jspc-compilers/jspc-compiler-tomcat5/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat5/JspCompilerImpl.java
@@ -115,6 +115,10 @@ public class JspCompilerImpl implements JspCompiler {
         //Unsupported in Tomcat 5
     }
 
+    public void setGenStringAsCharArray(boolean genStringAsCharArray) {
+        jspc.setGenStringAsCharArray(genStringAsCharArray);
+    }
+
     public void compile(Iterable<File> jspFiles) throws Exception {
         final List<String> args = new ArrayList<String>();
         

--- a/jspc-compilers/jspc-compiler-tomcat5/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat5/JspCompilerImpl.java
+++ b/jspc-compilers/jspc-compiler-tomcat5/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat5/JspCompilerImpl.java
@@ -119,6 +119,10 @@ public class JspCompilerImpl implements JspCompiler {
         jspc.setGenStringAsCharArray(genStringAsCharArray);
     }
 
+    public void setEnablePooling(boolean enablePooling) {
+        jspc.setPoolingEnabled(enablePooling);
+    }
+
     public void compile(Iterable<File> jspFiles) throws Exception {
         final List<String> args = new ArrayList<String>();
         

--- a/jspc-compilers/jspc-compiler-tomcat6/pom.xml
+++ b/jspc-compilers/jspc-compiler-tomcat6/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.jasig.mojo.jspc</groupId>
         <artifactId>jspc-compilers</artifactId>
-        <version>2.0.0.3-EBAY</version>
+        <version>2.0.0.4-EBAY</version>
     </parent>
     
     <artifactId>jspc-compiler-tomcat6</artifactId>

--- a/jspc-compilers/jspc-compiler-tomcat6/pom.xml
+++ b/jspc-compilers/jspc-compiler-tomcat6/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.jasig.mojo.jspc</groupId>
         <artifactId>jspc-compilers</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.0.0.1-EBAY</version>
     </parent>
     
     <artifactId>jspc-compiler-tomcat6</artifactId>

--- a/jspc-compilers/jspc-compiler-tomcat6/pom.xml
+++ b/jspc-compilers/jspc-compiler-tomcat6/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.jasig.mojo.jspc</groupId>
         <artifactId>jspc-compilers</artifactId>
-        <version>2.0.0.1-EBAY</version>
+        <version>2.0.0.2-EBAY</version>
     </parent>
     
     <artifactId>jspc-compiler-tomcat6</artifactId>

--- a/jspc-compilers/jspc-compiler-tomcat6/pom.xml
+++ b/jspc-compilers/jspc-compiler-tomcat6/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.jasig.mojo.jspc</groupId>
         <artifactId>jspc-compilers</artifactId>
-        <version>2.0.0.2-EBAY</version>
+        <version>2.0.0.3-EBAY</version>
     </parent>
     
     <artifactId>jspc-compiler-tomcat6</artifactId>

--- a/jspc-compilers/jspc-compiler-tomcat6/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat6/JspCompilerImpl.java
+++ b/jspc-compilers/jspc-compiler-tomcat6/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat6/JspCompilerImpl.java
@@ -115,6 +115,10 @@ public class JspCompilerImpl implements JspCompiler {
         //Unsupported in Tomcat 6
     }
 
+    public void setGenStringAsCharArray(boolean genStringAsCharArray) {
+        jspc.setGenStringAsCharArray(genStringAsCharArray);
+    }
+
     public void compile(Iterable<File> jspFiles) throws Exception {
         final List<String> args = new ArrayList<String>();
         

--- a/jspc-compilers/jspc-compiler-tomcat6/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat6/JspCompilerImpl.java
+++ b/jspc-compilers/jspc-compiler-tomcat6/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat6/JspCompilerImpl.java
@@ -111,6 +111,10 @@ public class JspCompilerImpl implements JspCompiler {
         jspc.setCompilerTargetVM(target);
     }
 
+    public void setELInterpreterClass(String elInterpreterClass) {
+        //Unsupported in Tomcat 6
+    }
+
     public void compile(Iterable<File> jspFiles) throws Exception {
         final List<String> args = new ArrayList<String>();
         

--- a/jspc-compilers/jspc-compiler-tomcat6/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat6/JspCompilerImpl.java
+++ b/jspc-compilers/jspc-compiler-tomcat6/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat6/JspCompilerImpl.java
@@ -119,6 +119,10 @@ public class JspCompilerImpl implements JspCompiler {
         jspc.setGenStringAsCharArray(genStringAsCharArray);
     }
 
+    public void setEnablePooling(boolean enablePooling) {
+        jspc.setPoolingEnabled(enablePooling);
+    }
+
     public void compile(Iterable<File> jspFiles) throws Exception {
         final List<String> args = new ArrayList<String>();
         

--- a/jspc-compilers/jspc-compiler-tomcat7/pom.xml
+++ b/jspc-compilers/jspc-compiler-tomcat7/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.jasig.mojo.jspc</groupId>
         <artifactId>jspc-compilers</artifactId>
-        <version>2.0.0.2-EBAY</version>
+        <version>2.0.0.3-EBAY</version>
     </parent>
     
     <artifactId>jspc-compiler-tomcat7</artifactId>

--- a/jspc-compilers/jspc-compiler-tomcat7/pom.xml
+++ b/jspc-compilers/jspc-compiler-tomcat7/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.jasig.mojo.jspc</groupId>
         <artifactId>jspc-compilers</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.0.0.1-EBAY</version>
     </parent>
     
     <artifactId>jspc-compiler-tomcat7</artifactId>

--- a/jspc-compilers/jspc-compiler-tomcat7/pom.xml
+++ b/jspc-compilers/jspc-compiler-tomcat7/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.jasig.mojo.jspc</groupId>
         <artifactId>jspc-compilers</artifactId>
-        <version>2.0.0.3-EBAY</version>
+        <version>2.0.0.4-EBAY</version>
     </parent>
     
     <artifactId>jspc-compiler-tomcat7</artifactId>

--- a/jspc-compilers/jspc-compiler-tomcat7/pom.xml
+++ b/jspc-compilers/jspc-compiler-tomcat7/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.jasig.mojo.jspc</groupId>
         <artifactId>jspc-compilers</artifactId>
-        <version>2.0.0.1-EBAY</version>
+        <version>2.0.0.2-EBAY</version>
     </parent>
     
     <artifactId>jspc-compiler-tomcat7</artifactId>

--- a/jspc-compilers/jspc-compiler-tomcat7/pom.xml
+++ b/jspc-compilers/jspc-compiler-tomcat7/pom.xml
@@ -32,7 +32,7 @@
     <name>JSPC Compiler for Tomcat 7</name>
 
     <properties>
-        <tomcatVersion>7.0.39</tomcatVersion>
+        <tomcatVersion>7.0.50</tomcatVersion>
     </properties>
     
     <dependencies>

--- a/jspc-compilers/jspc-compiler-tomcat7/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat7/JspCImpl.java
+++ b/jspc-compilers/jspc-compiler-tomcat7/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat7/JspCImpl.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.codehaus.mojo.jspc.compiler.tomcat7;
+
+import org.apache.jasper.JspC;
+
+import javax.servlet.ServletContext;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * JspC Implementation
+ */
+public class JspCImpl extends JspC {
+
+    private Map<String, String> parameters;
+
+    protected ServletContext getServletContext() {
+        if (context == null) {
+            initServletContext();
+        }
+        return context;
+    }
+
+    public void setContextInitParameter(String name, String value) {
+        if (parameters == null) {
+            parameters = new HashMap<String, String>();
+        }
+        parameters.put(name, value);
+    }
+
+    public void execute() {
+        if (parameters != null) {
+            for(Map.Entry<String, String> entry: parameters.entrySet())
+            getServletContext().setInitParameter(entry.getKey(), entry.getValue());
+        }
+        super.execute();
+    }
+}

--- a/jspc-compilers/jspc-compiler-tomcat7/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat7/JspCompilerImpl.java
+++ b/jspc-compilers/jspc-compiler-tomcat7/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat7/JspCompilerImpl.java
@@ -88,7 +88,7 @@ public class JspCompilerImpl implements JspCompiler {
     }
 
     public void setValidateXml(final boolean validateXml) {
-        jspc.setValidateXml(validateXml);
+        //jspc.setValidateXml(validateXml);
     }
 
     public void setTrimSpaces(final boolean trimSpaces) {

--- a/jspc-compilers/jspc-compiler-tomcat7/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat7/JspCompilerImpl.java
+++ b/jspc-compilers/jspc-compiler-tomcat7/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat7/JspCompilerImpl.java
@@ -33,12 +33,12 @@ import org.codehaus.mojo.jspc.compiler.JspCompiler;
  * @version $Id$
  */
 public class JspCompilerImpl implements JspCompiler {
-    private final JspC jspc;
+    private final JspCImpl jspc;
     private boolean showSuccess = false;
     private boolean listErrors = false;
-    
+
     public JspCompilerImpl() {
-        jspc = new JspC();
+        jspc = new JspCImpl();
         jspc.setFailOnError(true);
     }
 
@@ -111,21 +111,27 @@ public class JspCompilerImpl implements JspCompiler {
         jspc.setCompilerTargetVM(target);
     }
 
+    private static final String EL_INTERPRETER_CLASS = "org.apache.jasper.compiler.ELInterpreter";
+
+    public void setELInterpreterClass(String elInterpreterClass) {
+        jspc.setContextInitParameter(EL_INTERPRETER_CLASS, elInterpreterClass);
+    }
+
     public void compile(Iterable<File> jspFiles) throws Exception {
         final List<String> args = new ArrayList<String>();
-        
+
         if (showSuccess) {
             args.add("-s");
         }
-        
+
         if (listErrors) {
             args.add("-l");
         }
-        
+
         for (final File jspFile : jspFiles) {
             args.add(jspFile.getAbsolutePath());
         }
-        
+
         jspc.setArgs(args.toArray(new String[args.size()]));
 
         jspc.execute();

--- a/jspc-compilers/jspc-compiler-tomcat7/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat7/JspCompilerImpl.java
+++ b/jspc-compilers/jspc-compiler-tomcat7/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat7/JspCompilerImpl.java
@@ -117,6 +117,10 @@ public class JspCompilerImpl implements JspCompiler {
         jspc.setContextInitParameter(EL_INTERPRETER_CLASS, elInterpreterClass);
     }
 
+    public void setGenStringAsCharArray(boolean genStringAsCharArray) {
+        jspc.setGenStringAsCharArray(genStringAsCharArray);
+    }
+
     public void compile(Iterable<File> jspFiles) throws Exception {
         final List<String> args = new ArrayList<String>();
 

--- a/jspc-compilers/jspc-compiler-tomcat7/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat7/JspCompilerImpl.java
+++ b/jspc-compilers/jspc-compiler-tomcat7/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat7/JspCompilerImpl.java
@@ -121,6 +121,10 @@ public class JspCompilerImpl implements JspCompiler {
         jspc.setGenStringAsCharArray(genStringAsCharArray);
     }
 
+    public void setEnablePooling(boolean enablePooling) {
+        jspc.setPoolingEnabled(enablePooling);
+    }
+
     public void compile(Iterable<File> jspFiles) throws Exception {
         final List<String> args = new ArrayList<String>();
 

--- a/jspc-compilers/pom.xml
+++ b/jspc-compilers/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.jasig.mojo.jspc</groupId>
         <artifactId>jspc</artifactId>
-        <version>2.0.0.1-EBAY</version>
+        <version>2.0.0.2-EBAY</version>
     </parent>
     
     <artifactId>jspc-compilers</artifactId>

--- a/jspc-compilers/pom.xml
+++ b/jspc-compilers/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.jasig.mojo.jspc</groupId>
         <artifactId>jspc</artifactId>
-        <version>2.0.0.3-EBAY</version>
+        <version>2.0.0.4-EBAY</version>
     </parent>
     
     <artifactId>jspc-compilers</artifactId>

--- a/jspc-compilers/pom.xml
+++ b/jspc-compilers/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.jasig.mojo.jspc</groupId>
         <artifactId>jspc</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.0.0.1-EBAY</version>
     </parent>
     
     <artifactId>jspc-compilers</artifactId>
@@ -36,6 +36,7 @@
         <module>jspc-compiler-tomcat5</module>
         <module>jspc-compiler-tomcat6</module>
         <module>jspc-compiler-tomcat7</module>
+        
     </modules>
     
     <build>

--- a/jspc-compilers/pom.xml
+++ b/jspc-compilers/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.jasig.mojo.jspc</groupId>
         <artifactId>jspc</artifactId>
-        <version>2.0.0.2-EBAY</version>
+        <version>2.0.0.3-EBAY</version>
     </parent>
     
     <artifactId>jspc-compilers</artifactId>

--- a/jspc-maven-plugin/pom.xml
+++ b/jspc-maven-plugin/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.jasig.mojo.jspc</groupId>
         <artifactId>jspc</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.0.0.1-EBAY</version>
     </parent>
     
     <artifactId>jspc-maven-plugin</artifactId>

--- a/jspc-maven-plugin/pom.xml
+++ b/jspc-maven-plugin/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.jasig.mojo.jspc</groupId>
         <artifactId>jspc</artifactId>
-        <version>2.0.0.1-EBAY</version>
+        <version>2.0.0.2-EBAY</version>
     </parent>
     
     <artifactId>jspc-maven-plugin</artifactId>

--- a/jspc-maven-plugin/pom.xml
+++ b/jspc-maven-plugin/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.jasig.mojo.jspc</groupId>
         <artifactId>jspc</artifactId>
-        <version>2.0.0.2-EBAY</version>
+        <version>2.0.0.3-EBAY</version>
     </parent>
     
     <artifactId>jspc-maven-plugin</artifactId>

--- a/jspc-maven-plugin/pom.xml
+++ b/jspc-maven-plugin/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.jasig.mojo.jspc</groupId>
         <artifactId>jspc</artifactId>
-        <version>2.0.0.3-EBAY</version>
+        <version>2.0.0.4-EBAY</version>
     </parent>
     
     <artifactId>jspc-maven-plugin</artifactId>

--- a/jspc-maven-plugin/src/main/java/org/codehaus/mojo/jspc/CompilationMojoSupport.java
+++ b/jspc-maven-plugin/src/main/java/org/codehaus/mojo/jspc/CompilationMojoSupport.java
@@ -201,6 +201,9 @@ abstract class CompilationMojoSupport extends AbstractMojo {
     @Parameter(property="jspc.skip", defaultValue="false")
     boolean skip;
 
+    @Parameter(property="eLInterpreterClass")
+    String eLInterpreterClass;
+
     /**
      * Issue an error when the value of the class attribute in a useBean action is
      * not a valid bean class
@@ -284,6 +287,11 @@ abstract class CompilationMojoSupport extends AbstractMojo {
         final List<String> classpathElements = getClasspathElements();
         jspCompiler.setClasspath(classpathElements);
         log.debug("Classpath: " + classpathElements);
+
+        //EL Interpreter Class
+        if (eLInterpreterClass != null) {
+            jspCompiler.setELInterpreterClass(eLInterpreterClass);
+        }
         
         final List<File> jspFiles;
         if (sources.getIncludes() != null) {

--- a/jspc-maven-plugin/src/main/java/org/codehaus/mojo/jspc/CompilationMojoSupport.java
+++ b/jspc-maven-plugin/src/main/java/org/codehaus/mojo/jspc/CompilationMojoSupport.java
@@ -207,6 +207,10 @@ abstract class CompilationMojoSupport extends AbstractMojo {
     @Parameter(property = "genStringAsCharArray")
     boolean genStringAsCharArray;
 
+
+    @Parameter(property = "enablePooling", defaultValue="true")
+    boolean enablePooling;
+
     /**
      * Issue an error when the value of the class attribute in a useBean action is
      * not a valid bean class
@@ -298,6 +302,8 @@ abstract class CompilationMojoSupport extends AbstractMojo {
             jspCompiler.setELInterpreterClass(eLInterpreterClass);
         }
 
+        jspCompiler.setEnablePooling(enablePooling);
+
         jspCompiler.setGenStringAsCharArray(genStringAsCharArray);
         
         final List<File> jspFiles;
@@ -329,6 +335,7 @@ abstract class CompilationMojoSupport extends AbstractMojo {
         jspCompiler.setErrorOnUseBeanInvalidClassAttribute(errorOnUseBeanInvalidClassAttribute);
         jspCompiler.setCompilerSourceVM(source);
         jspCompiler.setCompilerTargetVM(target);
+
         
         // Make directories if needed
         workingDirectory.mkdirs();

--- a/jspc-maven-plugin/src/main/java/org/codehaus/mojo/jspc/CompilationMojoSupport.java
+++ b/jspc-maven-plugin/src/main/java/org/codehaus/mojo/jspc/CompilationMojoSupport.java
@@ -250,8 +250,9 @@ abstract class CompilationMojoSupport extends AbstractMojo {
         final boolean isWar = "war".equals(project.getPackaging());
 
         if (!isWar) {
-            log.warn("Compiled JSPs will not be added to the project and web.xml will " +
-                     "not be modified because the project's packaging is not 'war'.");
+            return;
+//            log.warn("Compiled JSPs will not be added to the project and web.xml will " +
+//                     "not be modified because the project's packaging is not 'war'.");
         }
         if (!includeInProject) {
             log.warn("Compiled JSPs will not be added to the project and web.xml will " +

--- a/jspc-maven-plugin/src/main/java/org/codehaus/mojo/jspc/CompilationMojoSupport.java
+++ b/jspc-maven-plugin/src/main/java/org/codehaus/mojo/jspc/CompilationMojoSupport.java
@@ -204,6 +204,9 @@ abstract class CompilationMojoSupport extends AbstractMojo {
     @Parameter(property="eLInterpreterClass")
     String eLInterpreterClass;
 
+    @Parameter(property = "genStringAsCharArray")
+    boolean genStringAsCharArray;
+
     /**
      * Issue an error when the value of the class attribute in a useBean action is
      * not a valid bean class
@@ -283,6 +286,7 @@ abstract class CompilationMojoSupport extends AbstractMojo {
         
         jspCompiler.setPackageName(packageName);
         log.debug("Package Name: " + this.packageName);
+
         
         final List<String> classpathElements = getClasspathElements();
         jspCompiler.setClasspath(classpathElements);
@@ -292,6 +296,8 @@ abstract class CompilationMojoSupport extends AbstractMojo {
         if (eLInterpreterClass != null) {
             jspCompiler.setELInterpreterClass(eLInterpreterClass);
         }
+
+        jspCompiler.setGenStringAsCharArray(genStringAsCharArray);
         
         final List<File> jspFiles;
         if (sources.getIncludes() != null) {

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <groupId>org.jasig.mojo.jspc</groupId>
     <artifactId>jspc</artifactId>
     <packaging>pom</packaging>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.0.1-EBAY</version>
     
     <name>JSPC Maven Support</name>
     <description>Provides support for JSP compilation.</description>
@@ -40,6 +40,17 @@
         <developerConnection>scm:git:git@github.com:Jasig/jspc-maven-plugin.git</developerConnection>
         <url>https://github.com/Jasig/jspc-maven-plugin</url>
     </scm>
+    
+    <distributionManagement>
+		<repository>
+			<id>raptor.thirdparty</id>
+			<url>http://ebaycentral/content/repositories/thirdparty/</url>
+		</repository>
+		<snapshotRepository>
+			<id>raptor.snapshots</id>
+			<url>http://ebaycentral/content/repositories/snapshots/</url>
+		</snapshotRepository>
+	</distributionManagement>
     
     <developers>
         <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <groupId>org.jasig.mojo.jspc</groupId>
     <artifactId>jspc</artifactId>
     <packaging>pom</packaging>
-    <version>2.0.0.1-EBAY</version>
+    <version>2.0.0.2-EBAY</version>
     
     <name>JSPC Maven Support</name>
     <description>Provides support for JSP compilation.</description>
@@ -43,8 +43,8 @@
     
     <distributionManagement>
 		<repository>
-			<id>raptor.thirdparty</id>
-			<url>http://ebaycentral/content/repositories/thirdparty/</url>
+			<id>raptor.plugins</id>
+			<url>http://ebaycentral/content/repositories/plugins/</url>
 		</repository>
 		<snapshotRepository>
 			<id>raptor.snapshots</id>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <groupId>org.jasig.mojo.jspc</groupId>
     <artifactId>jspc</artifactId>
     <packaging>pom</packaging>
-    <version>2.0.0.3-EBAY</version>
+    <version>2.0.0.4-EBAY</version>
     
     <name>JSPC Maven Support</name>
     <description>Provides support for JSP compilation.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <groupId>org.jasig.mojo.jspc</groupId>
     <artifactId>jspc</artifactId>
     <packaging>pom</packaging>
-    <version>2.0.0.2-EBAY</version>
+    <version>2.0.0.3-EBAY</version>
     
     <name>JSPC Maven Support</name>
     <description>Provides support for JSP compilation.</description>


### PR DESCRIPTION
1. Upgrade to latest tomcat version 7.0.50.  It removed xml validation feature. So there is a little bit code change for it.
2. ELInterpreter is interface to customize own java code for EL. It was supported after version 7.0.40. 
   We need this feature in JSPC as well.
