### PR TITLE
Bugfix: Build output directory was not added to classpath if it contained TLD files

### DIFF
--- a/jspc-compilers/jspc-compiler-tomcat7/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat7/JspCompilerImpl.java
+++ b/jspc-compilers/jspc-compiler-tomcat7/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat7/JspCompilerImpl.java
@@ -28,7 +28,7 @@ import org.apache.jasper.JspC;
 import org.codehaus.mojo.jspc.compiler.JspCompiler;
 
 /**
- * JSP compiler for Tomcat 6.
+ * JSP compiler for Tomcat 7.
  *
  * @version $Id$
  */

--- a/jspc-maven-plugin/src/main/java/org/codehaus/mojo/jspc/CompilationMojoSupport.java
+++ b/jspc-maven-plugin/src/main/java/org/codehaus/mojo/jspc/CompilationMojoSupport.java
@@ -217,7 +217,7 @@ abstract class CompilationMojoSupport extends AbstractMojo {
      * The Maven project.
      */
     @Component
-    private MavenProject project;
+    protected MavenProject project;
     
     @Component( role = MavenFileFilter.class, hint = "default" )
     private MavenFileFilter mavenFileFilter;

--- a/jspc-maven-plugin/src/main/java/org/codehaus/mojo/jspc/CompileMojo.java
+++ b/jspc-maven-plugin/src/main/java/org/codehaus/mojo/jspc/CompileMojo.java
@@ -80,10 +80,6 @@ public class CompileMojo extends CompilationMojoSupport {
                         }
                         tldExists = true;
                     }
-                    //Fix for https://jira.codehaus.org/browse/MJSPC-60
-                    else {
-                        list.add(target);
-                    }
                 }
             }
 
@@ -110,6 +106,8 @@ public class CompileMojo extends CompilationMojoSupport {
         finally {
             FileUtils.deleteQuietly(tempJarDir);
         }
+        //Fix for https://jira.codehaus.org/browse/MJSPC-60
+        list.add(project.getBuild().getOutputDirectory());
         return list;
     }
 

--- a/jspc-maven-plugin/src/main/java/org/codehaus/mojo/jspc/CompileMojo.java
+++ b/jspc-maven-plugin/src/main/java/org/codehaus/mojo/jspc/CompileMojo.java
@@ -111,12 +111,19 @@ public class CompileMojo extends CompilationMojoSupport {
             FileUtils.deleteQuietly(tempJarDir);
         }
         addBuildOutputDirectoryTo(list);
+        addWebAppOutputDirectoryTo(list); // FIXME Workaround: Exploded .war folder until Tomcat 7 can be used
         return list;
     }
 
     private void addBuildOutputDirectoryTo(List<String> list) {
         // If output directory contained .TLD files it wasn't added before. This is verified and done here if necessary.
         if (classpathElements.contains(project.getBuild().getOutputDirectory()) && !list.contains(project.getBuild().getOutputDirectory())) {
+            list.add(project.getBuild().getOutputDirectory());
+        }
+    }
+
+    private void addWebAppOutputDirectoryTo(List<String> list) {
+        if (!list.contains(project.getBuild().getOutputDirectory())) {
             list.add(project.getBuild().getOutputDirectory());
         }
     }


### PR DESCRIPTION
Whenever any directory on the classpath contains TLD files, the directory itself would not be added to the classpath. This also applies to the build output directoy, which seems not intended (https://jira.codehaus.org/browse/MJSPC-60).

This has been fixed by checking if the build output directory was a) part of the classpathElements and b) not yet in the classpath list. If both applies, it is added to the classpath.