### PR TITLE
Do not copy compiled JSPs to output directory if "includeInProject" is set to false

### DIFF
--- a/jspc-compilers/jspc-compiler-tomcat7/pom.xml
+++ b/jspc-compilers/jspc-compiler-tomcat7/pom.xml
@@ -32,7 +32,7 @@
     <name>JSPC Compiler for Tomcat 7</name>
 
     <properties>
-        <tomcatVersion>7.0.39</tomcatVersion>
+        <tomcatVersion>7.0.55</tomcatVersion>
     </properties>
     
     <dependencies>

--- a/jspc-compilers/jspc-compiler-tomcat7/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat7/JspCompilerImpl.java
+++ b/jspc-compilers/jspc-compiler-tomcat7/src/main/java/org/codehaus/mojo/jspc/compiler/tomcat7/JspCompilerImpl.java
@@ -150,7 +150,7 @@ public class JspCompilerImpl implements JspCompiler {
 					ArrayList<String> argList = new ArrayList<String>(args);
 					argList.add(jspFile.getAbsolutePath());
 					JspC jspc = new JspC(); 
-					jspc.setFailOnError(true);
+					jspc.setFailOnError(failOnError);
 			        jspc.setUriroot(webappDir);
 			        jspc.setOutputDir(outputDirectory.getAbsolutePath());
 			        jspc.setJavaEncoding(encoding);

--- a/jspc-maven-plugin/src/main/java/org/codehaus/mojo/jspc/CompilationMojoSupport.java
+++ b/jspc-maven-plugin/src/main/java/org/codehaus/mojo/jspc/CompilationMojoSupport.java
@@ -259,6 +259,7 @@ abstract class CompilationMojoSupport extends AbstractMojo {
         if (sources == null) {
             sources = new FileSet();
             sources.setDirectory(this.defaultSourcesDirectory.getAbsolutePath());
+            sources.setIncludes(Arrays.asList("**/*.jsp"));
             sources.setExcludes(Arrays.asList("WEB-INF/web.xml", "META-INF/**"));
         }
 
@@ -330,17 +331,16 @@ abstract class CompilationMojoSupport extends AbstractMojo {
             // Show a nice message when we know how many files are included
             if (!jspFiles.isEmpty()) {
                 log.info("Compiling " + jspFiles.size() + " JSP source file" + (jspFiles.size() > 1 ? "s" : "") + " to " + workingDirectory);
+                final StopWatch watch = new StopWatch();
+                watch.start();
+                
+                jspCompiler.compile(jspFiles);
+                
+                log.info("Compilation completed in " + watch);
             }
             else {
-                log.info("Compiling JSP source files to " + workingDirectory);
+                log.info("No JSP source files found.");
             }
-            
-            final StopWatch watch = new StopWatch();
-            watch.start();
-            
-            jspCompiler.compile(jspFiles);
-            
-            log.info("Compilation completed in " + watch);
         }
         catch (Exception e) {
             throw new MojoFailureException("Failed to compile JSPS", e);

--- a/jspc-maven-plugin/src/main/java/org/codehaus/mojo/jspc/CompilationMojoSupport.java
+++ b/jspc-maven-plugin/src/main/java/org/codehaus/mojo/jspc/CompilationMojoSupport.java
@@ -356,7 +356,7 @@ abstract class CompilationMojoSupport extends AbstractMojo {
         }
         
         // Maybe install the generated classes into the default output directory
-        if (compile && isWar) {
+        if (includeInProject && compile && isWar) {
             final Scanner scanner = buildContext.newScanner(this.workingDirectory);
             scanner.addDefaultExcludes();
             scanner.setIncludes(new String[] { "**/*.class" });


### PR DESCRIPTION
Currently compiled JSPs (.class-files) are copied into the output directory even if "includeInProject" is set to false.

I'm just using the plugin to check if all JSPs can be compiled before deploying the application to the production servers. 

The compiled JSPs should only be copied to the output directory and thus included in the project if "includeInProject" is set to true. Currently the parameter name is misleading.
