### PR TITLE
#32 Update to use latest Tomcat version for compiler.

### DIFF
--- a/jspc-compilers/jspc-compiler-tomcat8/pom.xml
+++ b/jspc-compilers/jspc-compiler-tomcat8/pom.xml
@@ -32,7 +32,7 @@
     <name>JSPC Compiler for Tomcat 8</name>
 
     <properties>
-        <tomcatVersion>8.0.15</tomcatVersion>
+        <tomcatVersion>8.0.36</tomcatVersion>
     </properties>
     
     <dependencies>


### PR DESCRIPTION
Solves compatibility issue with latest Tomcat releases. 
But, creates files that are not compatible with old Tomcat 8 versions any longer (e.g. 8.0.24). 
