### PR TITLE
Add Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: java
+jdk: oraclejdk8

--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
-### Info
+# JSPC Maven Plugin
+
+[![Build Status](https://travis-ci.org/Jasig/jspc-maven-plugin.svg?branch=master)](https://travis-ci.org/Jasig/jspc-maven-plugin)
+
+## Info
+
 A Maven plugin that compiles JSPs into class files, copies these into the final artifact, and updates the web.xml to reference the compiled classes. This is a fork of the [Codehaus jspc-maven-plugin](http://mojo.codehaus.org/jspc/jspc-maven-plugin/) that resolves some long standing issues and gets the Tomcat 7 support released.
 
-### Usage
+## Usage
+
 See the [Maven Project Documentation](http://developer.jasig.org/projects/jspc-maven-plugin/2.0.0/jspc-maven-plugin/plugin-info.html) for goal documentation.
 
 [Plugin Usage](http://developer.jasig.org/projects/jspc-maven-plugin/2.0.0/jspc-maven-plugin/usage.html) is also documented on the maven site.
 
-### JSP Compilers
-The available JSP compilers can be found by browsing [org.jasig.mojo.jspc GroupId](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.jasig.mojo.jspc%22).
+## JSP Compilers
 
+The available JSP compilers can be found by browsing [org.jasig.mojo.jspc GroupId](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.jasig.mojo.jspc%22).


### PR DESCRIPTION
Example output: https://travis-ci.org/ChristianMurphy/jspc-maven-plugin/builds/213149766

Would need Travis CI to be switched on for Repository.