### PR TITLE
Don't try to find tools.jar if compile is false

### DIFF
--- a/jspc-maven-plugin/src/main/java/org/codehaus/mojo/jspc/CompilationMojoSupport.java
+++ b/jspc-maven-plugin/src/main/java/org/codehaus/mojo/jspc/CompilationMojoSupport.java
@@ -366,7 +366,9 @@ abstract class CompilationMojoSupport extends AbstractMojo {
         // JspC needs URLClassLoader, with tools.jar
         final ClassLoader parent = Thread.currentThread().getContextClassLoader();
         final JspcMojoClassLoader cl = new JspcMojoClassLoader(parent);
-        cl.addURL(findToolsJar());
+        if(compile) {
+            cl.addURL(findToolsJar());
+        }
         Thread.currentThread().setContextClassLoader(cl);
 
         try {


### PR DESCRIPTION
Motivation for this change: tools.jar doesn't exist any longer on java 9.
